### PR TITLE
fix: keep package versions synchronized

### DIFF
--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -54,24 +54,21 @@ find_version_file() {
 }
 
 VERSION_FILE=$(find_version_file)
-TARGET=""
 CURRENT_VERSION=""
 
-if [ -n "$VERSION_FILE" ]; then
+if [ -f "pyproject.toml" ]; then
+    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -Eq '(^pyproject\.toml$|_version\.py$)'; then
+        exit 0
+    fi
+    CURRENT_VERSION=$(grep -oP '^version = "\K[^"]+' pyproject.toml 2>/dev/null || true)
+elif [ -n "$VERSION_FILE" ]; then
     if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q '_version.py'; then
         exit 0
     fi
     CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' "$VERSION_FILE" 2>/dev/null || true)
-    TARGET="version_file"
-elif [ -f "pyproject.toml" ]; then
-    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q '^pyproject.toml$'; then
-        exit 0
-    fi
-    CURRENT_VERSION=$(grep -oP '^version = "\K[^"]+' pyproject.toml 2>/dev/null || true)
-    [ -n "$CURRENT_VERSION" ] && TARGET="pyproject"
 fi
 
-if [ -z "$CURRENT_VERSION" ] || [ -z "$TARGET" ]; then
+if [ -z "$CURRENT_VERSION" ]; then
     exit 0
 fi
 
@@ -84,12 +81,13 @@ echo -e "${BLUE}📦 Auto-bumping version: $CURRENT_VERSION → $NEW_VERSION${NC
 
 touch .git/SAGE_POST_COMMIT_RUNNING
 
-if [ "$TARGET" = "version_file" ]; then
-    sed -i "s/__version__ = \"${CURRENT_VERSION}\"/__version__ = \"${NEW_VERSION}\"/" "$VERSION_FILE"
-    git add "$VERSION_FILE"
-else
-    sed -i "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" pyproject.toml
+if [ -f "pyproject.toml" ]; then
+    sed -E -i "s/^version = \"[^\"]+\"/version = \"${NEW_VERSION}\"/" pyproject.toml
     git add pyproject.toml
+fi
+if [ -n "$VERSION_FILE" ]; then
+    sed -E -i "s/__version__ = \"[^\"]+\"/__version__ = \"${NEW_VERSION}\"/" "$VERSION_FILE"
+    git add "$VERSION_FILE"
 fi
 
 git commit --amend --no-edit --no-verify

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -75,19 +75,18 @@ find_version_files() {
 
 # Update version in pyproject.toml (static) and/or _version.py (dynamic)
 update_version() {
-    local old_version="$1"
     local new_version="$2"
     local updated=false
 
     if grep -q '^version = "' pyproject.toml 2>/dev/null; then
-        sed -i "s/version = \"${old_version}\"/version = \"${new_version}\"/" pyproject.toml
+        sed -E -i "s/^version = \"[^\"]+\"/version = \"${new_version}\"/" pyproject.toml
         git add pyproject.toml
         updated=true
     fi
 
     while IFS= read -r VERSION_FILE; do
         if [ -f "$VERSION_FILE" ] && grep -q '__version__ = "' "$VERSION_FILE" 2>/dev/null; then
-            sed -i "s/__version__ = \"${old_version}\"/__version__ = \"${new_version}\"/" "$VERSION_FILE"
+            sed -E -i "s/__version__ = \"[^\"]+\"/__version__ = \"${new_version}\"/" "$VERSION_FILE"
             git add "$VERSION_FILE"
             updated=true
         fi
@@ -99,6 +98,25 @@ update_version() {
     fi
 
     return 0
+}
+
+ensure_version_files_match() {
+    local expected_version="$1"
+    local mismatch=false
+    local actual_version
+
+    while IFS= read -r VERSION_FILE; do
+        actual_version=$(grep -oP '__version__ = "\K[^"]+' "$VERSION_FILE" 2>/dev/null || true)
+        if [ "$actual_version" != "$expected_version" ]; then
+            echo -e "${RED}✗ Version mismatch: ${VERSION_FILE}=${actual_version:-missing}, pyproject.toml=${expected_version}${NC}"
+            mismatch=true
+        fi
+    done < <(find_version_files)
+
+    if [ "$mismatch" = true ]; then
+        echo -e "${YELLOW}  Synchronize and commit all version files before pushing.${NC}"
+        return 1
+    fi
 }
 
 # Auto-increment the last version component by 1 (X.Y.Z → X.Y.Z+1, X.Y.Z.N → X.Y.Z.N+1)
@@ -226,22 +244,26 @@ fi
 
 PACKAGE_NAME=$(grep -oP '^name = "\K[^"]+' pyproject.toml 2>/dev/null || echo "unknown")
 
-# Get version: prefer _version.py (dynamic), fallback to pyproject.toml (static)
+# pyproject.toml is the canonical package version.  Synchronize generated
+# _version.py files before checking PyPI so an older drift cannot perpetuate.
 CURRENT_VERSION=""
-while IFS= read -r VERSION_FILE; do
-    if [ -f "$VERSION_FILE" ]; then
-        CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' "$VERSION_FILE" 2>/dev/null || true)
-        [ -n "$CURRENT_VERSION" ] && break
-    fi
-done < <(find_version_files)
-
-if [ -z "$CURRENT_VERSION" ]; then
+if [ -f "pyproject.toml" ]; then
     CURRENT_VERSION=$(grep -oP '^version = "\K[^"]+' pyproject.toml 2>/dev/null || true)
+fi
+if [ -z "$CURRENT_VERSION" ]; then
+    while IFS= read -r VERSION_FILE; do
+        if [ -f "$VERSION_FILE" ]; then
+            CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' "$VERSION_FILE" 2>/dev/null || true)
+            [ -n "$CURRENT_VERSION" ] && break
+        fi
+    done < <(find_version_files)
 fi
 
 if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "unknown" ]; then
     exit 0
 fi
+
+ensure_version_files_match "$CURRENT_VERSION"
 
 # --- Version / Publish ---
 # post-commit already bumps the BUILD digit on every commit, so by the time

--- a/src/sage_libs/sage_finetune/_version.py
+++ b/src/sage_libs/sage_finetune/_version.py
@@ -1,5 +1,5 @@
 """Version information for isage-finetune."""
 
-__version__ = "0.1.0.7"
+__version__ = "0.2.0"
 __author__ = "IntelliStream Team"
 __email__ = "shuhao_zhang@hust.edu.cn"

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,21 @@
+"""Regression tests for package version metadata."""
+
+import re
+from pathlib import Path
+
+
+def read_version(path: Path, pattern: str) -> str:
+    match = re.search(pattern, path.read_text(), re.MULTILINE)
+    assert match is not None
+    return match.group(1)
+
+
+def test_runtime_version_matches_project_metadata():
+    """The runtime version file must match the build metadata."""
+    root = Path(__file__).parents[1]
+    project_version = read_version(root / "pyproject.toml", r'^version = "([^"]+)"$')
+    runtime_version = read_version(
+        root / "src/sage_libs/sage_finetune/_version.py",
+        r'^__version__ = "([^"]+)"$',
+    )
+    assert runtime_version == project_version


### PR DESCRIPTION
## Summary

- make `pyproject.toml` the canonical version source for the release hooks;
- update both `pyproject.toml` and every packaged `_version.py` during automatic bumps;
- fail the pre-push check when runtime metadata has drifted instead of publishing an inconsistent package;
- align the current runtime version with project metadata (`0.2.0`);
- add a dependency-free regression test for metadata consistency.

Closes #1.

Issue #2 is an exact duplicate and can close with this fix as well.

## Validation

```text
bash -n hooks/pre-push hooks/post-commit
python3 -m pytest -q tests/test_version_sync.py
git diff --check
```

The focused regression test passes. Full test collection on the review host is currently blocked by the repository's external `sage` package dependency, which is not installed in that environment.
